### PR TITLE
Update cb2.gemspec

### DIFF
--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -2,6 +2,7 @@ Gem::Specification.new do |s|
   s.name = "cb2"
   s.email = "pedrobelo@gmail.com"
   s.version = "0.0.3"
+  s.license = "MIT"
   s.summary = "Circuit breaker"
   s.description = "Implementation of the circuit breaker pattern in Ruby"
   s.authors = ["Pedro Belo"]


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.
