### PR TITLE
Update cb2.gemspec to support redis 4.x and 5.x gem versions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cb2 (0.0.4)
-      redis (~> 5, >= 4)
+      redis (>= 4)
 
 GEM
   remote: http://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
     connection_pool (2.4.1)
     diff-lcs (1.5.0)
     minitest (5.18.1)
+    mutex_m (0.3.0)
     rake (13.0.6)
     redis (5.2.0)
       redis-client (>= 0.22.0)
@@ -37,6 +38,7 @@ PLATFORMS
 DEPENDENCIES
   cb2!
   minitest (> 0)
+  mutex_m (> 0)
   rake (> 0)
   rr (~> 1.1)
   rspec (~> 3.1)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ breaker = CB2::Breaker.new(
 
 This might be the only percent-based breaker in Ruby so far. For count-based breakers (eg: open after X exceptions) you can also check [breaker_box](https://github.com/sittercity/breaker_box) and [circuit_breaker](https://github.com/wsargent/circuit_breaker).
 
+## Development
+
+Running the tests locally requires a running `redis` service listening on port `6379`. If the service is not running locally, use a `container`:
+
+```
+docker run -p 6379:6379 -d redis
+bundle exec rspec
+```
+
 ## Meta
 
 Created by Pedro Belo.

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.1"
   s.add_development_dependency "minitest", "> 0"
   s.add_development_dependency "timecop", "> 0"
+  s.add_development_dependency "mutex_m", "> 0"
 end

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", "~> 5", ">= 4"
+  s.add_dependency "redis", ">= 4"
   s.add_development_dependency "rake", "> 0"
   s.add_development_dependency "rr", "~> 1.1"
   s.add_development_dependency "rspec", "~> 3.1"


### PR DESCRIPTION
PR to support issue: https://github.com/prognostikos/cb2/issues/16